### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/francoispqt/gojay v1.2.13
 	github.com/gofiber/fiber/v2 v2.42.0
 	github.com/r3labs/diff/v3 v3.0.1
-	github.com/tetratelabs/wazero v1.0.0-pre.8
+	github.com/tetratelabs/wazero v1.0.1
 	github.com/valyala/fasthttp v1.44.0
 )
 

--- a/src/go.sum
+++ b/src/go.sum
@@ -124,8 +124,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
-github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/src/pokerface/main.go
+++ b/src/pokerface/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/francoispqt/gojay"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/proxy"
-	diff "github.com/r3labs/diff/v3"
+	"github.com/r3labs/diff/v3"
 	"github.com/sandrolain/go-pokerface/src/cert"
 	"github.com/sandrolain/go-pokerface/src/pokerface/shared"
 	"github.com/tetratelabs/wazero"
@@ -326,7 +326,7 @@ func executeWasm(req *shared.RequestInfo, f *Forward, c *fiber.Ctx) (res *shared
 
 	// Instantiate the guest Wasm into the same runtime. It exports the `add`
 	// function, implemented in WebAssembly.
-	mod, err := r.InstantiateModuleFromBinary(ctx, f.WasmData)
+	mod, err := r.Instantiate(ctx, f.WasmData)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.